### PR TITLE
Bosgood/agent demo fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,7 @@ out/
 # Misc
 .DS_Store
 *.pem
-.vercel 
+.vercel
+
+# Raindrop
+.raindrop/

--- a/agent-template/.raindrop/config.json
+++ b/agent-template/.raindrop/config.json
@@ -1,3 +1,0 @@
-{
-  "versionId": "01jdn9n1n0drcth3yaz3rnxff5"
-}

--- a/agent-template/README.md
+++ b/agent-template/README.md
@@ -15,6 +15,7 @@ A template for creating and deploying AI agents using the Raindrop platform.
    ```shell
    git clone git@github.com:LiquidMetal-AI/liquidmetal-demos.git
    cd liquidmetal-demos/agent-template
+   npm install
    ```
 
 2. Configure your project:
@@ -28,6 +29,10 @@ A template for creating and deploying AI agents using the Raindrop platform.
    ```shell
    raindrop build branch
    raindrop build deploy
+   raindrop build env set agent-template:env:GROQ_API_KEY <your-groq-api-key>
+   raindrop build env set agent-template:env:NEWS_API_KEY <your-news-api-key>
+   raindrop build env set agent-template:env:WEATHER_API_KEY <your-openweather-api-key>
+   raindrop build start
    ```
 
 7. Send a request to your agent using `cURL`


### PR DESCRIPTION
# Why?

These steps make the agent-template demo easier to follow.

# What

* [CHANGE] Add `npm install` to setup dev env properly
* [CHANGE] Add steps to setup the raindrop service's envvars as well
* [CHANGE] gitignore Raindrop-internal data that will differ for all users

